### PR TITLE
Potential security issue in src/toMetalOperand.cpp: Unchecked return from initialization function

### DIFF
--- a/src/toMetalOperand.cpp
+++ b/src/toMetalOperand.cpp
@@ -1073,7 +1073,7 @@ std::string ToMetal::TranslateVariableName(const Operand* psOperand, uint32_t ui
         }
         case OPERAND_TYPE_INPUT_PATCH_CONSTANT:
         {
-            const ShaderInfo::InOutSignature* psIn;
+            const ShaderInfo::InOutSignature* psIn = nullptr;
             psContext->psShader->sInfo.GetPatchConstantSignatureFromRegister(psOperand->ui32RegisterNumber, psOperand->GetAccessMask(), &psIn);
             *piRebase = psIn->iRebase;
             switch (psIn->eSystemValueType)


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `src/toMetalOperand.cpp` 
Function: `GetPatchConstantSignatureFromRegister@ShaderInfo` 
https://github.com/sagpant/HLSLcc/blob/45cd5126a8e95bbf755f6c68af9f9befb97ded5b/src/toMetalOperand.cpp#L1077
Code extract:

```cpp
        case OPERAND_TYPE_INPUT_PATCH_CONSTANT:
        {
            const ShaderInfo::InOutSignature* psIn;
            psContext->psShader->sInfo.GetPatchConstantSignatureFromRegister(psOperand->ui32RegisterNumber, psOperand->GetAccessMask(), &psIn); <------ HERE
            *piRebase = psIn->iRebase;
            switch (psIn->eSystemValueType)
```

